### PR TITLE
Update signal-cli submodule master at 22f19c4

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.11)
 set(PROJECT_NAME "purple-signal")
 project(${PROJECT_NAME})
-set(SIGNAL_CLI_JAR "signal-cli-0.6.12.jar")
+set(SIGNAL_CLI_JAR "signal-cli-0.7.1.jar")
 add_subdirectory(java)
 add_subdirectory(c)


### PR DESCRIPTION
These changes allow interfacing with the newer version of the signal-cli library.
The main change is that `dataPath` is expected to be a File object, rather
than a string.

This PR relies on the changes made in https://github.com/hoehermann/signal-cli/pull/1. 

I should note that 0.7.1 is not yet released. You may want to hold off on this until it is. 